### PR TITLE
Исправить проблему с повторным открытием окна логов

### DIFF
--- a/index.js
+++ b/index.js
@@ -2230,8 +2230,8 @@ input[type=number] {
     this._stopHttpFallback();
     this._stopLatencyMonitoring();
     this._unbindSocket();
-    // Отписка от live логов
-    try { if (this.logs) { this.logs.unsubscribe(); } } catch(_) {}
+    // Отписка от live логов и очистка обработчиков
+    try { if (this.logs) { this.logs.unsubscribe(); this.logs.cleanup(); } } catch(_) {}
 
     // Полностью удаляем панель из DOM при закрытии
     try { if (this.root && this.root.parentNode) this.root.parentNode.removeChild(this.root); } catch(_) {}


### PR DESCRIPTION
Implement proper event listener and socket handler cleanup for the log inspector to fix issues with reopening the log panel.

When the main inspector window was closed, its log panel's DOM elements were removed, but associated event listeners and WebSocket handlers remained active. This caused the log panel to become unresponsive or behave incorrectly upon subsequent attempts to open it, as new elements were created but old handlers were still referencing non-existent DOM nodes or duplicating socket subscriptions. This PR introduces a robust cleanup mechanism to ensure all resources are properly released when the panel is hidden, preventing these issues and adhering to web best practices for component lifecycle management.

---
<a href="https://cursor.com/background-agent?bcId=bc-076a13b9-49f5-4505-84e3-78b7964170ee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-076a13b9-49f5-4505-84e3-78b7964170ee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

